### PR TITLE
Removed debug messages

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -3,7 +3,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-#define DEBUG		//!< Constant to define the debug mode. If not defined, the functions will not print anything.
+//#define DEBUG		//!< Constant to define the debug mode. If not defined, the functions will not print anything.
 
 
 #ifndef NUM_WHEEL_ROVER_MAX


### PR DESCRIPTION
By default the debug messages are enabled, this spams the terminal quite a lot. I suggest to disable the  debug messages by default and document its usage instead.